### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glob": "^7.0.3",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
-    "gulp-minify": "0.0.5",
+    "gulp-minify": "0.0.14",
     "gulp-minify-css": "^1.2.4",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.1",


### PR DESCRIPTION
trails-example-express-gulp is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `gulp-minify`

This PR fixes the ReDoS vulnerability by upgrading `gulp-minify` to version 0.0.14 This upgrade will also fix the following other vulnerabilities:
- [ReDos vulnerabilty](https://snyk.io/vuln/npm:uglify-js:20151024) in the `uglify-js` dependency.

Check out the [Snyk test report](https://snyk.io/test/github/jaumard/trails-example-express-gulp) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
